### PR TITLE
Fix requeue message command

### DIFF
--- a/src/connection.rs
+++ b/src/connection.rs
@@ -468,7 +468,7 @@ async fn write_req<S: AsyncWrite + std::marker::Unpin>(
 ) -> Result<(), Error> {
     stream.write_all(b"REQ ").await?;
     stream.write_all(&id).await?;
-    stream.write_all(b" \n").await?;
+    stream.write_all(b" ").await?;
     stream.write_all(count.to_string().as_bytes()).await?;
     stream.write_all(b"\n").await?;
 


### PR DESCRIPTION
REQ command used to trigger the following error:

```
ERROR [tokio_nsq::connection] fatal protocol error = E_INVALID invalid command 90000
```

Because the REQ command was malformed (a spurious `\n` between the `id` and the `timeout`.