### PR TITLE
Buffered IO & locks

### DIFF
--- a/src/connection.rs
+++ b/src/connection.rs
@@ -683,6 +683,7 @@ async fn run_connection(state: &mut NSQDConnectionState) -> Result<(), Error> {
     if let Some(timeout) = state.config.shared.read_timeout {
         stream.set_read_timeout(timeout);
     }
+    let mut stream = tokio::io::BufReader::new(stream);
 
     let hostname = match &state.config.shared.hostname {
         Some(hostname) => hostname.clone(),

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -1048,7 +1048,7 @@ impl NSQDConnection {
     }
 
     pub fn queue_message(
-        &mut self,
+        &self,
         message: MessageToNSQ,
     ) -> Result<(), Error> {
         if self.shared.healthy.load(Ordering::SeqCst) {

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -773,6 +773,9 @@ async fn run_connection(state: &mut NSQDConnectionState) -> Result<(), Error> {
         let config = TlsConnector::from(config);
         let dnsname = DNSNameRef::try_from_ascii_str(&config_tls.domain_name)?;
 
+        // Turn stream back into TcpStream as rustls does buffering itself
+        let stream = stream.into_inner().into_inner();
+
         let stream = config.connect(dnsname, stream).await?;
 
         let (mut stream_rx, stream_tx) = tokio::io::split(stream);

--- a/src/consumer.rs
+++ b/src/consumer.rs
@@ -304,8 +304,7 @@ async fn lookup_supervisor(
 
 async fn rebalancer_step(
     max_in_flight: u32,
-    clients_ref: &std::sync::RwLock<HashMap<String, NSQConnectionMeta>,
-    >,
+    clients_ref: &std::sync::RwLock<HashMap<String, NSQConnectionMeta>>,
 ) -> bool {
     let guard = clients_ref.read().unwrap();
 

--- a/src/consumer.rs
+++ b/src/consumer.rs
@@ -243,7 +243,7 @@ async fn lookup(
                 None => {
                     info!("new producer: {}", address);
 
-                    let mut client = NSQDConnection::new_with_queue(
+                    let client = NSQDConnection::new_with_queue(
                         NSQDConfig {
                             address: address.clone(),
                             shared: config.shared.clone(),
@@ -308,13 +308,13 @@ async fn rebalancer_step(
         std::sync::Mutex<HashMap<String, NSQConnectionMeta>>,
     >,
 ) -> bool {
-    let mut guard = clients_ref.lock().unwrap();
+    let guard = clients_ref.lock().unwrap();
 
     let mut healthy = Vec::new();
 
-    for (_, node) in guard.iter_mut() {
+    for (_, node) in guard.iter() {
         if node.connection.healthy() {
-            healthy.push(&mut node.connection);
+            healthy.push(&node.connection);
         }
     }
 
@@ -326,7 +326,7 @@ async fn rebalancer_step(
 
     let partial = if partial == 0 { 1 } else { partial };
 
-    for node in healthy.iter_mut() {
+    for node in &healthy {
         let _ = NSQDConnection::queue_message(
             *node,
             MessageToNSQ::RDY(partial as u16),


### PR DESCRIPTION
* switch to using buffered reader & writer on top of TcpStream, as it significantly reduces syscall numbers
* replace clients Mutex with RwLock as it's mostly read, not written