### PR TITLE
refactor: replace failure with anyhow/thiserror

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,8 @@ tokio             = { version = "^1.0", features = ["full"] }
 serde             = { version = "1.0", features = ["derive"] }
 serde_json        = "1.0"
 byteorder         = "1.3"
-failure           = "0.1.8"
+anyhow 		  = "1.0"
+thiserror 	  = "1.0"
 log               = "0.4"
 tokio-rustls      = "^0.22"
 rustls            = { version = "0.19", features = ["dangerous_configuration"] }

--- a/src/consumer.rs
+++ b/src/consumer.rs
@@ -1,5 +1,5 @@
 use ::core::result::Result;
-use ::failure::Error;
+use ::anyhow::Error;
 use ::log::*;
 use ::std::collections::HashMap;
 use ::std::collections::HashSet;

--- a/src/producer.rs
+++ b/src/producer.rs
@@ -1,5 +1,5 @@
 use ::core::result::Result;
-use ::failure::Error;
+use ::anyhow::Error;
 use ::std::sync::Arc;
 
 use crate::connection::*;


### PR DESCRIPTION
 failure is deprecated, see https://github.com/rust-lang-deprecated/failure