### PR TITLE
Relax borrowing rule on `TOUCH` command

### DIFF
--- a/src/connection.rs
+++ b/src/connection.rs
@@ -171,7 +171,7 @@ impl NSQMessage {
     }
 
     /// Tells NSQ daemon to reset the timeout for this message.
-    pub async fn touch(&mut self) {
+    pub async fn touch(&self) {
         if self.context.healthy.load(Ordering::SeqCst) {
             let _ = self
                 .context


### PR DESCRIPTION
Hello :wave: 

I've some functionality which requires the `TOUCH` method, and I think this seems to not require mutable borrowing of the event object, so we could remove the signature requirement. This shouldn't be a breaking changes since existing code would already have the mutable ownership